### PR TITLE
Can't delete this class from the markup

### DIFF
--- a/src/less/myacct.less
+++ b/src/less/myacct.less
@@ -69,6 +69,12 @@
     margin-right: 10px;
   }
 }
+.template-dir-myresearch.template-name-mylist {
+    .callnumAndLocation {
+        margin-top: 0;
+        margin-bottom:0;
+    }
+}
 
 
 // ** Alerts ** //


### PR DESCRIPTION
This is needed because we cannot delete the .callnumAndLocation class. It is used by the javascript for implementing ajax calls.